### PR TITLE
Store the source location, not self-reported

### DIFF
--- a/controllers/meta.js
+++ b/controllers/meta.js
@@ -150,7 +150,7 @@ module.exports.addRemoteMeta = function (remoteUri, lastModified, lastSystemUpda
             return cb();
           }
 
-          payload.meta_uri = payload.meta_uri || remoteUri;
+          payload.meta_uri = remoteUri;
 
           // create a geojson object from footprint and bbox
           // TODO: Put in a Mongoose middleware hook


### PR DESCRIPTION
I'm not totally convinced this is the right solution (maybe create records for each URI?), but this does prevent repeated indexing of metadata that doesn't include URI references to itself.