### PR TITLE
[WiP] RemoteCatalog support

### DIFF
--- a/controllers/meta.js
+++ b/controllers/meta.js
@@ -3,7 +3,7 @@
 var _ = require('lodash');
 var request = require('request');
 var parse = require('wellknown');
-var bboxPolygon = require('turf-bbox-polygon');
+var bboxPolygon = require('@turf/bbox-polygon');
 var Boom = require('boom');
 
 var Meta = require('../models/meta.js');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@mapbox/sphericalmercator": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz",
+      "integrity": "sha1-cCN7l3QJXtHP286nqP0fyCsmkfI="
+    },
     "@turf/bbox": {
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-4.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,14 @@
   "homepage": "https://github.com/hotosm/oam-catalog",
   "dependencies": {
     "@mapbox/sphericalmercator": "^1.0.5",
+    "@turf/area": "^6.0.1",
     "@turf/bbox": "^4.7.3",
+    "@turf/bbox-polygon": "^6.0.1",
     "@turf/envelope": "^5.0.4",
+    "@turf/intersect": "^6.1.2",
     "@turf/invariant": "^4.7.3",
     "@turf/meta": "^6.0.1",
+    "@turf/union": "^6.0.2",
     "async": "2.1.4",
     "aws-sdk": "^2.66.0",
     "babel": "^5.8.21",
@@ -58,7 +62,6 @@
     "request": "^2.60.0",
     "sendgrid": "^1.9.2",
     "tmp": "0.0.26",
-    "turf-bbox-polygon": "^1.0.1",
     "uuid": "^3.0.1",
     "wellknown": "^0.3.1",
     "xtend": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/hotosm/oam-catalog",
   "dependencies": {
+    "@mapbox/sphericalmercator": "^1.0.5",
     "@turf/bbox": "^4.7.3",
     "@turf/envelope": "^5.0.4",
     "@turf/invariant": "^4.7.3",

--- a/routes/meta.js
+++ b/routes/meta.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var bboxPolygon = require('turf-bbox-polygon');
+var bboxPolygon = require('@turf/bbox-polygon');
 var Boom = require('boom');
 var merc = new (require('@mapbox/sphericalmercator'))();
 

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,8 +1,13 @@
 'use strict';
 
 var _ = require('lodash');
+// var area = require('@turf/area').default;
+var bboxPolygon = require('@turf/bbox-polygon').default;
 var Boom = require('boom');
+// var intersect = require('@turf/intersect').default;
 var Joi = require('joi');
+var merc = new (require('@mapbox/sphericalmercator'))();
+// var union = require('@turf/union').default;
 
 var User = require('../models/user');
 var Meta = require('../models/meta');
@@ -87,6 +92,154 @@ module.exports = [
         });
       }).catch(function (err) {
         reply(Boom.badImplementation(err));
+      });
+    }
+  },
+
+  {
+    method: 'GET',
+    path: '/user/{user}/catalog.json',
+    config: {
+      tags: ['disablePlugins']
+    },
+    handler: (request, reply) => {
+      const { user } = request.params;
+
+      return Promise.all([
+        User.findOne({
+          _id: user
+        }, {
+          name: 1,
+          website: 1
+        }),
+        Meta.find({
+          user
+        }, {
+          bbox: 1, gsd: 1
+        })
+      ])
+        .then(([user, images]) => {
+          const approximateZoom = Math.floor(images
+            .map(meta => Math.ceil(Math.log2(2 * Math.PI * 6378137 / (meta.gsd * 256))))
+            .reduce((a, b) => a + b) / images.length);
+
+          const bounds = images.reduce((bbox, meta) =>
+            [
+              Math.min(bbox[0], meta.bbox[0]),
+              Math.min(bbox[1], meta.bbox[1]),
+              Math.max(bbox[2], meta.bbox[2]),
+              Math.max(bbox[3], meta.bbox[3])
+            ], [Infinity, Infinity, -Infinity, -Infinity]);
+
+          return reply({
+            name: user.name,
+            bounds: bounds,
+            center: [
+              (bounds[0] + bounds[2]) / 2,
+              (bounds[1] + bounds[3]) / 2,
+              approximateZoom - 3
+            ],
+            maxzoom: approximateZoom + 3,
+            minzoom: approximateZoom - 10
+          });
+        })
+        .catch(err => reply(Boom.badImplementation(err.message)));
+    }
+  },
+
+  {
+    method: 'GET',
+    path: '/user/{user}/{z}/{x}/{y}.json',
+    config: {
+      tags: ['disablePlugins']
+    },
+    handler: (request, reply) => {
+      const { user, z, x, y } = request.params;
+
+      const bbox = merc.bbox(x, y, z);
+      const { geometry } = bboxPolygon(bbox);
+
+      return Meta.find({
+        user,
+        geojson: {
+          $geoIntersects: {
+            $geometry: geometry
+          }
+        }
+      }, {
+        acquisition_end: 1,
+        geojson: 1,
+        gsd: 1,
+        title: 1,
+        uuid: 1
+      }, {
+        sort: {
+          gsd: 1,
+          acquisition_end: -1
+        }
+      }).then(images => {
+        if (images.length === 0) {
+          return reply(Boom.notFound());
+        }
+
+        // NOTE source prioritization is currently disabled due to
+        // https://github.com/w8r/martinez/issues/74, which is triggered by
+        // geometries in the Zanzibar imagery
+        const sources = images;
+
+        // // for filtering; more readable than embedding everything into reduce()
+        // let tileArea = area(geometry);
+        // let totalArea = 0;
+        // let totalOverlap = null;
+        // let filled = false;
+        //
+        // // sort by overlap
+        // const sources = images
+        //   // calculate overlap with the target tile
+        //   .map(image => Object.assign(image, {
+        //     overlap: intersect(geometry, image.geojson)
+        //   }))
+        //   // sort by overlap
+        //   .sort((a, b) => area(b.overlap) - area(a.overlap))
+        //   // filter unnecessary sources
+        //   .filter(x => {
+        //     if (filled) {
+        //       // already full
+        //       return false;
+        //     }
+        //
+        //     const newOverlap = totalOverlap == null ? x.overlap : union(totalOverlap, x.overlap);
+        //     const newArea = area(newOverlap);
+        //
+        //     if (newArea > totalArea) {
+        //       // this source contributes
+        //       if (newArea === tileArea) {
+        //         // now full
+        //         filled = true;
+        //       }
+        //
+        //       totalOverlap = newOverlap;
+        //       totalArea = newArea;
+        //       return true;
+        //     }
+        //
+        //     return false;
+        //   });
+
+        return reply(sources
+          .map(meta => ({
+            url: meta.uuid,
+            name: meta.title,
+            acquired_at: meta.acquisition_end,
+            resolution: meta.gsd,
+            recipes: {
+              imagery: true
+            }
+          })));
+      })
+      .catch(err => {
+        console.warn(err.stack);
+        return reply(Boom.badImplementation(err.message));
       });
     }
   }

--- a/routes/user.js
+++ b/routes/user.js
@@ -108,10 +108,7 @@ module.exports = [
       return Promise.all([
         User.findOne({
           _id: user
-        }, {
-          name: 1,
-          website: 1
-        }),
+        }, 'name website'),
         Meta.find({
           user
         }, {
@@ -166,13 +163,7 @@ module.exports = [
             $geometry: geometry
           }
         }
-      }, {
-        acquisition_end: 1,
-        geojson: 1,
-        gsd: 1,
-        title: 1,
-        uuid: 1
-      }, {
+      }, 'acquisition_end geojson gsd title uid', {
         sort: {
           gsd: 1,
           acquisition_end: -1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,28 @@
 # yarn lockfile v1
 
 
+"@mapbox/sphericalmercator@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz#70237b9774095ed1cfdbcea7a8fd1fc82b2691f2"
+
+"@turf/area@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/area/-/area-6.0.1.tgz#50ed63c70ef2bdb72952384f1594319d94f3b051"
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+
 "@turf/bbox-polygon@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz#6aeba4ed51d85d296e0f7c38b88c339f01eee024"
   dependencies:
     "@turf/helpers" "^5.1.5"
+
+"@turf/bbox-polygon@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-6.0.1.tgz#ae0fbb14558831fb34538aae089a23d3336c6379"
+  dependencies:
+    "@turf/helpers" "6.x"
 
 "@turf/bbox@^4.7.3":
   version "4.7.3"
@@ -37,9 +54,29 @@
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
 
+"@turf/intersect@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@turf/intersect/-/intersect-6.1.2.tgz#eaf5e8915af601978a8b65851bc73db57cf5919c"
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    martinez-polygon-clipping "*"
+
+"@turf/invariant@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.0.1.tgz#45581b41f82d91b682cef427e897c840d1741757"
+  dependencies:
+    "@turf/helpers" "6.x"
+
 "@turf/invariant@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-4.7.3.tgz#538f367d23c113fc849d70c9a524b8563874601d"
+
+"@turf/meta@6.x", "@turf/meta@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.0.1.tgz#cf6f3f2263a3d24fc8d6a7e90f0420bbc44c090d"
+  dependencies:
+    "@turf/helpers" "6.x"
 
 "@turf/meta@^4.7.3":
   version "4.7.4"
@@ -51,11 +88,13 @@
   dependencies:
     "@turf/helpers" "^5.1.5"
 
-"@turf/meta@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.0.1.tgz#cf6f3f2263a3d24fc8d6a7e90f0420bbc44c090d"
+"@turf/union@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/union/-/union-6.0.2.tgz#6821d7842f048cfcfe1ae3b7c36fec73bd7e89cd"
   dependencies:
     "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    martinez-polygon-clipping "*"
 
 abbrev@1:
   version "1.1.1"
@@ -337,6 +376,10 @@ asynckit@^0.4.0:
 atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
+
+avl@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/avl/-/avl-1.4.2.tgz#55cef61e6e6ae26a899a929f5c57d25b4afb2cae"
 
 aws-sdk@^2.66.0:
   version "2.171.0"
@@ -2842,6 +2885,13 @@ markdown-it@^5.0.2:
     mdurl "~1.0.1"
     uc.micro "^1.0.0"
 
+martinez-polygon-clipping@*:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/martinez-polygon-clipping/-/martinez-polygon-clipping-0.3.3.tgz#a7b9429c9d13cb118a86c97a5e1af5a62aedb6d9"
+  dependencies:
+    avl "^1.4.1"
+    tinyqueue "^1.2.0"
+
 mdurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
@@ -4296,6 +4346,10 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
+tinyqueue@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-1.2.3.tgz#b6a61de23060584da29f82362e45df1ec7353f3d"
+
 tmp@0.0.26:
   version "0.0.26"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.26.tgz#9efa820ce2a10f81f8979555bace3f15526ce1f2"
@@ -4376,16 +4430,6 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
-
-turf-bbox-polygon@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/turf-bbox-polygon/-/turf-bbox-polygon-1.0.2.tgz#488b223fb787761161fa332bffa1dd8fd5bd09d1"
-  dependencies:
-    turf-polygon "^1.0.2"
-
-turf-polygon@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/turf-polygon/-/turf-polygon-1.0.3.tgz#671dd34849864509281af18e236f67a7448c6363"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
Support for marblecutter's [`RemoteCatalog`](https://github.com/mojodna/marblecutter/blob/master/marblecutter/catalogs/remote.py).

Configuring [marblecutter-openaerialmap](https://github.com/mojodna/marblecutter-openaerialmap) with `REMOTE_CATALOG_BASE_URL=http://<host>:<port>` (a development instance with this branch) will enable http://localhost:8000/o/global/preview as a global TMS.

(The diff will clean itself up after #121 is merged.)