### PR TITLE
Batch improvements

### DIFF
--- a/services/transcoder.js
+++ b/services/transcoder.js
@@ -1,14 +1,17 @@
 var cp = require('child_process');
+var url = require('url');
 
 var AWS = require('aws-sdk');
 var monq = require('monq');
 var promisify = require('es6-promisify');
+var request = require('request');
 
 var config = require('../config');
 
 var batch = new AWS.Batch();
 var client = monq(config.dbUri);
 var queue = client.queue('transcoder');
+var s3 = new AWS.S3();
 var s3bucket = config.oinBucket;
 
 module.exports.transcode = (sourceUrl, output, metaUrl, callback) => {
@@ -51,19 +54,68 @@ module.exports.transcode = (sourceUrl, output, metaUrl, callback) => {
   });
 };
 
+var getSize = (sourceUrl, callback) => {
+  var uri = url.parse(sourceUrl);
+
+  switch (uri.protocol) {
+    case "s3:":
+      return s3.headObject({
+        Bucket: uri.hostname,
+        Key: uri.pathname.slice(1)
+      }, (err, data) => {
+        if (err) {
+          return callback(err);
+        }
+
+        return callback(null, data.ContentLength);
+      });
+
+    default:
+      return request.head(sourceUrl, (err, rsp) => {
+        if (err) {
+          return callback(err);
+        }
+
+        return callback(null, rsp.headers['content-length']);
+      });
+  }
+};
+
+var guessMemoryAllocation = (sourceUrl, callback) =>
+  getSize(sourceUrl, (err, size) => {
+    if (err) {
+      console.warn(err.stack);
+      return callback(null, 3000);
+    }
+
+    var mbs = Math.ceil(size / (1024 * 1024));
+
+    // optimistic about source encoding; assume it's the smallest it can be (but
+    // cap allocated memory at 30GB)
+    // provide a minimum for smaller images
+    var recommended = Math.max(3000, Math.min(30000, mbs * 10));
+
+    return callback(null, recommended);
+  });
+
 var batchTranscode = (jobName, input, output, callbackUrl, callback) =>
-  batch.submitJob(
-    {
-      jobDefinition: config.batch.jobDefinition,
-      jobName,
-      jobQueue: config.batch.jobQueue,
-      parameters: {
-        input,
-        output,
-        callback_url: callbackUrl
-      }
-    },
-    (err, data) => callback(err)
+  guessMemoryAllocation(input, (err, memory) =>
+    batch.submitJob(
+      {
+        jobDefinition: config.batch.jobDefinition,
+        jobName,
+        jobQueue: config.batch.jobQueue,
+        parameters: {
+          input,
+          output,
+          callback_url: callbackUrl
+        },
+        containerOverrides: {
+          memory
+        }
+      },
+      (err, data) => callback(err)
+    )
   );
 
 var monqTranscode = (sourceUrl, output, metaUrl, callback) =>

--- a/services/transcoder.js
+++ b/services/transcoder.js
@@ -61,10 +61,6 @@ var batchTranscode = (jobName, input, output, callbackUrl, callback) =>
         input,
         output,
         callback_url: callbackUrl
-      },
-      retryStrategy: {
-        // allow for intermittent platform errors
-        attempts: 2
       }
     },
     (err, data) => callback(err)


### PR DESCRIPTION
This dynamically requests memory from Batch according to the size of the input image. Heuristics seem hard to come by, as the same image may require lots of memory whether it's ~120GB or 2.6 (https://github.com/hotosm/OpenAerialMap/issues/102). This is optimistic about file compression (so, pessimistic about how much memory is needed) and multiplies by 10x w/ a 30GB cap and 3GB minimum (same as before).