### PR TITLE
User mosaics

### DIFF
--- a/controllers/meta.js
+++ b/controllers/meta.js
@@ -3,7 +3,7 @@
 var _ = require('lodash');
 var request = require('request');
 var parse = require('wellknown');
-var bboxPolygon = require('turf-bbox-polygon');
+var bboxPolygon = require('@turf/bbox-polygon');
 var Boom = require('boom');
 
 var Meta = require('../models/meta.js');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,20 +4,45 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@mapbox/sphericalmercator": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz",
+      "integrity": "sha1-cCN7l3QJXtHP286nqP0fyCsmkfI="
+    },
+    "@turf/area": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.0.1.tgz",
+      "integrity": "sha512-Zv+3N1ep9P5JvR0YOYagLANyapGWQBh8atdeR3bKpWcigVXFsEKNUw03U/5xnh+cKzm7yozHD6MFJkqQv55y0g==",
+      "requires": {
+        "@turf/helpers": "6.1.3",
+        "@turf/meta": "6.0.1"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.3.tgz",
+          "integrity": "sha512-nBbSk/hi7WC+5F/CKbfkB42ckIm7jms79DutLCD9Q5AYVITNxitP5uPrgE+Sf4VPFTBaEe0e8yzFCRzH9+SAzw=="
+        }
+      }
+    },
     "@turf/bbox": {
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-4.7.3.tgz",
-      "integrity": "sha1-461PEKfptBtSKIDTMIMZgZkFkGc=",
-      "requires": {
-        "@turf/meta": "4.7.3"
-      }
+      "integrity": "sha1-461PEKfptBtSKIDTMIMZgZkFkGc="
     },
     "@turf/bbox-polygon": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.0.4.tgz",
-      "integrity": "sha1-26KkQqxqq0R895JQUrOBde1+/XA=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.0.1.tgz",
+      "integrity": "sha512-f6BK6GOzUNjmJeOYHklk/5LNcQMQbo51gvAM10dTM5IqzKP01KM5bgV88uOKfSZB0HRQVpaRV1tgXk2bg5cPRg==",
       "requires": {
-        "@turf/helpers": "5.0.4"
+        "@turf/helpers": "6.1.3"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.3.tgz",
+          "integrity": "sha512-nBbSk/hi7WC+5F/CKbfkB42ckIm7jms79DutLCD9Q5AYVITNxitP5uPrgE+Sf4VPFTBaEe0e8yzFCRzH9+SAzw=="
+        }
       }
     },
     "@turf/envelope": {
@@ -26,7 +51,6 @@
       "integrity": "sha1-1/5+LekPGA6XqlzeM6a6UpNcA9I=",
       "requires": {
         "@turf/bbox": "5.0.4",
-        "@turf/bbox-polygon": "5.0.4",
         "@turf/helpers": "5.0.4"
       },
       "dependencies": {
@@ -54,15 +78,75 @@
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.0.4.tgz",
       "integrity": "sha1-5HpOTzje47R6MXemneFi16elg38="
     },
+    "@turf/intersect": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.1.2.tgz",
+      "integrity": "sha512-Uv5Nwn4tn2uKvCVNL33DtxFSZe24pmp67JDI5eFkl9BkDrhCUL4epdMxCfZZNTanGqneXiZ2g+tE2+FCN2RoiA==",
+      "requires": {
+        "@turf/helpers": "6.1.3",
+        "@turf/invariant": "6.0.1",
+        "martinez-polygon-clipping": "0.3.3"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.3.tgz",
+          "integrity": "sha512-nBbSk/hi7WC+5F/CKbfkB42ckIm7jms79DutLCD9Q5AYVITNxitP5uPrgE+Sf4VPFTBaEe0e8yzFCRzH9+SAzw=="
+        },
+        "@turf/invariant": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.0.1.tgz",
+          "integrity": "sha512-yN2GSDgVjRS2LIE+JN2TQmkk2q3z8FwBNFJ1Pw5BUfa1ybR3euk+s6blvYNT95Lu8H46EeSaYTcwMvgpiQneoA==",
+          "requires": {
+            "@turf/helpers": "6.1.3"
+          }
+        }
+      }
+    },
     "@turf/invariant": {
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-4.7.3.tgz",
       "integrity": "sha1-U482fSPBE/yEnXDJpSS4Vjh0YB0="
     },
     "@turf/meta": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-4.7.3.tgz",
-      "integrity": "sha1-A4lwF46QyOQ899/tedV4IpihCA0="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.1.tgz",
+      "integrity": "sha512-+2mBdPM2sOrjbpm41OwzbFXqs0Vl05IRthFwbTfA4+QIhu97SvcMbX406P3QEerMPFtKEb33f01e4yMrEot/AA==",
+      "requires": {
+        "@turf/helpers": "6.1.3"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.3.tgz",
+          "integrity": "sha512-nBbSk/hi7WC+5F/CKbfkB42ckIm7jms79DutLCD9Q5AYVITNxitP5uPrgE+Sf4VPFTBaEe0e8yzFCRzH9+SAzw=="
+        }
+      }
+    },
+    "@turf/union": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-6.0.2.tgz",
+      "integrity": "sha512-HT3VYillzl0nPIDSl1TStjKSJ6Hh+yOen+8P/OGeXgcFQAI4abLRMogFGcOw2pkxg288kMm1Cfi4BKl+BY3ziA==",
+      "requires": {
+        "@turf/helpers": "6.1.3",
+        "@turf/invariant": "6.0.1",
+        "martinez-polygon-clipping": "0.3.3"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.3.tgz",
+          "integrity": "sha512-nBbSk/hi7WC+5F/CKbfkB42ckIm7jms79DutLCD9Q5AYVITNxitP5uPrgE+Sf4VPFTBaEe0e8yzFCRzH9+SAzw=="
+        },
+        "@turf/invariant": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.0.1.tgz",
+          "integrity": "sha512-yN2GSDgVjRS2LIE+JN2TQmkk2q3z8FwBNFJ1Pw5BUfa1ybR3euk+s6blvYNT95Lu8H46EeSaYTcwMvgpiQneoA==",
+          "requires": {
+            "@turf/helpers": "6.1.3"
+          }
+        }
+      }
     },
     "abbrev": {
       "version": "1.1.1",
@@ -654,6 +738,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "avl": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/avl/-/avl-1.4.2.tgz",
+      "integrity": "sha512-I+TCAKq/xvg56ye61HS/16F6PezL1eNTf9siT6Lxu3gE7uqHWAtJ006cum5w/rmo8OBRIOIMwVDL75nwolKF4w=="
+    },
     "aws-sdk": {
       "version": "2.115.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.115.0.tgz",
@@ -1117,6 +1206,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
       "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
     },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -1127,13 +1221,13 @@
       }
     },
     "bell": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/bell/-/bell-8.7.0.tgz",
-      "integrity": "sha1-7lkfFuUQcwQBtaSPLGXP90jWnTw=",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/bell/-/bell-8.9.0.tgz",
+      "integrity": "sha512-tibCCgKaP9ahjGAJs/YDpAWWZyLmlvJfjMa7ElPA9/mkmCvswedvouI0DVRaa/1zfKqQ9GTy6Y2ZMhCfJbCPfQ==",
       "requires": {
         "boom": "4.2.0",
         "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "joi": "10.6.0",
         "wreck": "10.0.0"
       },
@@ -1143,31 +1237,8 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-4.2.0.tgz",
           "integrity": "sha1-wadBdLEfu6Ij9hYtT9iFGhuCpTY=",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
         }
       }
     },
@@ -1258,10 +1329,21 @@
         }
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-shims": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "build-url": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/build-url/-/build-url-1.1.1.tgz",
+      "integrity": "sha512-Mmb8PESAk+PpVfY+41+tnmuA9QDylO3aYny/Ohj5g503a72ny4ZmlrV3DZwdw4YA9tKvAQyoG3p8tNmvLoyzbA==",
+      "dev": true
     },
     "call": {
       "version": "4.0.2",
@@ -2438,6 +2520,11 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
       "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
     },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
     "core-decorators": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.17.0.tgz",
@@ -2478,6 +2565,24 @@
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
+      }
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
       }
     },
     "crypto-browserify": {
@@ -2789,6 +2894,22 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
+      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "requires": {
+        "base64url": "2.0.0",
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "ecstatic": {
@@ -4152,6 +4273,16 @@
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
+      }
+    },
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
@@ -4550,31 +4681,6 @@
         }
       }
     },
-    "hapi-auth-bearer-token": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/hapi-auth-bearer-token/-/hapi-auth-bearer-token-5.1.0.tgz",
-      "integrity": "sha1-jgnWXGOlKOY5uxFV10391WksMQ4=",
-      "requires": {
-        "boom": "4.3.1",
-        "hoek": "4.2.0",
-        "joi": "10.6.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-        }
-      }
-    },
     "hapi-auth-cookie": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/hapi-auth-cookie/-/hapi-auth-cookie-7.0.0.tgz",
@@ -4608,6 +4714,31 @@
             "moment": "2.18.1",
             "topo": "2.0.2"
           }
+        }
+      }
+    },
+    "hapi-auth-jwt2": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/hapi-auth-jwt2/-/hapi-auth-jwt2-7.4.1.tgz",
+      "integrity": "sha1-n40NnaICq4aLEr/yIMk8fH7+ff0=",
+      "requires": {
+        "boom": "6.0.0",
+        "cookie": "0.3.1",
+        "jsonwebtoken": "8.2.1"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-6.0.0.tgz",
+          "integrity": "sha512-LYLa8BmiiOWjvxTMVh73lcZzd2E5yczrKvxAny1UuzO2tkarLrw4tdp3rdfmus3+YfKcZP0vRSM3Obh+fGK6eA==",
+          "requires": {
+            "hoek": "5.0.3"
+          }
+        },
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
         }
       }
     },
@@ -4792,6 +4923,11 @@
           "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
         }
       }
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "home-or-tmp": {
       "version": "1.0.0",
@@ -5191,6 +5327,12 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
@@ -5305,6 +5447,30 @@
         "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+      "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
+      "requires": {
+        "jws": "3.1.4",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5323,6 +5489,41 @@
         }
       }
     },
+    "jwa": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
+      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "requires": {
+        "base64url": "2.0.0",
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.9",
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "jws": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
+      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "requires": {
+        "base64url": "2.0.0",
+        "jwa": "1.1.5",
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "kareem": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz",
@@ -5335,1689 +5536,6 @@
       "dev": true,
       "requires": {
         "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-      }
-    },
-    "lab": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/lab/-/lab-5.18.1.tgz",
-      "integrity": "sha1-Sr87Q/up/YnlFaIzCL5RzWdnyGU=",
-      "dev": true,
-      "requires": {
-        "bossy": "1.0.3",
-        "diff": "2.2.3",
-        "eslint": "1.5.1",
-        "eslint-config-hapi": "2.0.1",
-        "eslint-plugin-hapi": "1.2.2",
-        "espree": "2.2.5",
-        "handlebars": "4.0.10",
-        "hoek": "2.16.3",
-        "items": "1.1.1",
-        "jslint": "0.9.8",
-        "json-stringify-safe": "5.0.1",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.3.3"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-          "dev": true,
-          "optional": true
-        },
-        "align-text": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "argparse": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-          "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "1.0.3"
-          }
-        },
-        "array-union": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-          "dev": true,
-          "requires": {
-            "array-uniq": "1.0.3"
-          }
-        },
-        "array-uniq": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "bossy": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/bossy/-/bossy-1.0.3.tgz",
-          "integrity": "sha1-p9JHiuDC33X0cJi5ute9ZB7tX68=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "circular-json": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-          "dev": true
-        },
-        "cli-width": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "d": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true,
-          "requires": {
-            "es5-ext": "0.10.30"
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true,
-          "optional": true
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-          "dev": true
-        },
-        "del": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-          "dev": true,
-          "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.6.2"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            }
-          }
-        },
-        "diff": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
-          "dev": true
-        },
-        "doctrine": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
-          "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
-          "dev": true,
-          "requires": {
-            "esutils": "1.1.6",
-            "isarray": "0.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            }
-          }
-        },
-        "es5-ext": {
-          "version": "0.10.30",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
-          "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
-          "dev": true,
-          "requires": {
-            "es6-iterator": "2.0.1",
-            "es6-symbol": "3.1.1"
-          }
-        },
-        "es6-iterator": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-          "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-          "dev": true,
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-symbol": "3.1.1"
-          }
-        },
-        "es6-map": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-          "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-          "dev": true,
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-iterator": "2.0.1",
-            "es6-set": "0.1.5",
-            "es6-symbol": "3.1.1",
-            "event-emitter": "0.3.5"
-          }
-        },
-        "es6-set": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-          "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-          "dev": true,
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-iterator": "2.0.1",
-            "es6-symbol": "3.1.1",
-            "event-emitter": "0.3.5"
-          }
-        },
-        "es6-symbol": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "dev": true,
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30"
-          }
-        },
-        "es6-weak-map": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-          "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-          "dev": true,
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-iterator": "2.0.1",
-            "es6-symbol": "3.1.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "escope": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-          "dev": true,
-          "requires": {
-            "es6-map": "0.1.5",
-            "es6-weak-map": "2.0.2",
-            "esrecurse": "4.2.0",
-            "estraverse": "4.2.0"
-          }
-        },
-        "eslint": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
-          "integrity": "sha1-u54WHwFh1xuF3EgWO/FKhvICVis=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "concat-stream": "1.6.0",
-            "debug": "2.6.8",
-            "doctrine": "0.7.2",
-            "escape-string-regexp": "1.0.5",
-            "escope": "3.6.0",
-            "espree": "2.2.5",
-            "estraverse": "4.2.0",
-            "estraverse-fb": "1.3.2",
-            "file-entry-cache": "1.3.1",
-            "glob": "5.0.15",
-            "globals": "8.18.0",
-            "handlebars": "4.0.10",
-            "inquirer": "0.9.0",
-            "is-my-json-valid": "2.16.1",
-            "is-resolvable": "1.0.0",
-            "js-yaml": "3.10.0",
-            "lodash.clonedeep": "3.0.2",
-            "lodash.merge": "3.3.2",
-            "lodash.omit": "3.1.0",
-            "minimatch": "2.0.10",
-            "mkdirp": "0.5.1",
-            "object-assign": "2.1.1",
-            "optionator": "0.5.0",
-            "path-is-absolute": "1.0.1",
-            "path-is-inside": "1.0.2",
-            "shelljs": "0.3.0",
-            "strip-json-comments": "1.0.4",
-            "text-table": "0.2.0",
-            "to-double-quotes": "1.0.2",
-            "to-single-quotes": "1.0.4",
-            "user-home": "1.1.1",
-            "xml-escape": "1.0.0"
-          }
-        },
-        "eslint-config-hapi": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-2.0.1.tgz",
-          "integrity": "sha1-OR7kokI6icim5QduQ04W+IkaqXI=",
-          "dev": true
-        },
-        "eslint-plugin-hapi": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-1.2.2.tgz",
-          "integrity": "sha1-QcwGNDhxibEcAGdWM6cVZGq4lJA=",
-          "dev": true,
-          "requires": {
-            "hapi-capitalize-modules": "1.1.6",
-            "hapi-scope-start": "1.1.4",
-            "no-shadow-relaxed": "1.0.1"
-          }
-        },
-        "espree": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
-          "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
-          "dev": true
-        },
-        "esrecurse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-          "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-          "dev": true,
-          "requires": {
-            "estraverse": "4.2.0",
-            "object-assign": "4.1.1"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            }
-          }
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-          "dev": true
-        },
-        "estraverse-fb": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
-          "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
-          "dev": true
-        },
-        "esutils": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
-          "dev": true
-        },
-        "event-emitter": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-          "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-          "dev": true,
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30"
-          }
-        },
-        "exit": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-          "dev": true,
-          "optional": true
-        },
-        "fast-levenshtein": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-          "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
-          "dev": true
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            }
-          }
-        },
-        "file-entry-cache": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
-          "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
-          "dev": true,
-          "requires": {
-            "flat-cache": "1.2.2",
-            "object-assign": "4.1.1"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            }
-          }
-        },
-        "flat-cache": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-          "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-          "dev": true,
-          "requires": {
-            "circular-json": "0.3.3",
-            "del": "2.2.2",
-            "graceful-fs": "4.1.11",
-            "write": "0.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-          "dev": true
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-          "dev": true,
-          "requires": {
-            "is-property": "1.0.2"
-          }
-        },
-        "get-stdin": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
-          "integrity": "sha1-wc7SS5A5s43thb3xYeV3E7bdSr4=",
-          "dev": true
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "globals": {
-          "version": "8.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-          "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
-          "dev": true
-        },
-        "globby": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.10",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-          "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
-          }
-        },
-        "hapi-capitalize-modules": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
-          "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
-          "dev": true
-        },
-        "hapi-scope-start": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-1.1.4.tgz",
-          "integrity": "sha1-VxC1r7dOdJYdrn6wmdjYvkp1sA4=",
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
-          "integrity": "sha1-c2bjijMeYZBJWKzlstpKml9jZ5g=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-width": "1.1.1",
-            "figures": "1.7.0",
-            "lodash": "3.10.1",
-            "readline2": "0.1.1",
-            "run-async": "0.1.0",
-            "rx-lite": "2.5.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
-          }
-        },
-        "is-buffer": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-          "dev": true
-        },
-        "is-my-json-valid": {
-          "version": "2.16.1",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-          "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
-          "dev": true,
-          "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "is-path-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-          "dev": true
-        },
-        "is-path-in-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-          "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-          "dev": true,
-          "requires": {
-            "is-path-inside": "1.0.0"
-          }
-        },
-        "is-path-inside": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-          "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-          "dev": true,
-          "requires": {
-            "path-is-inside": "1.0.2"
-          }
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-          "dev": true
-        },
-        "is-resolvable": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-          "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-          "dev": true,
-          "requires": {
-            "tryit": "1.0.3"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "items": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/items/-/items-1.1.1.tgz",
-          "integrity": "sha1-Q1td0hvKKLPP0lu1xrJ4txUBD9k=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-              "dev": true
-            }
-          }
-        },
-        "jslint": {
-          "version": "0.9.8",
-          "resolved": "https://registry.npmjs.org/jslint/-/jslint-0.9.8.tgz",
-          "integrity": "sha1-uSyoXKhtaoKXchCO6RnshJ3EsSk=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "exit": "0.1.2",
-            "glob": "4.5.3",
-            "nopt": "3.0.6",
-            "readable-stream": "1.0.34"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "2.0.10",
-                "once": "1.4.0"
-              }
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true,
-              "optional": true
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-          "dev": true,
-          "optional": true
-        },
-        "levn": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-          "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lodash._arraycopy": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-          "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
-          "dev": true
-        },
-        "lodash._arrayeach": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-          "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
-          "dev": true
-        },
-        "lodash._arraymap": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
-          "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
-          "dev": true
-        },
-        "lodash._baseassign": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-          "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-          "dev": true,
-          "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash.keys": "3.1.2"
-          }
-        },
-        "lodash._baseclone": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-          "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
-          "dev": true,
-          "requires": {
-            "lodash._arraycopy": "3.0.0",
-            "lodash._arrayeach": "3.0.0",
-            "lodash._baseassign": "3.2.0",
-            "lodash._basefor": "3.0.3",
-            "lodash.isarray": "3.0.4",
-            "lodash.keys": "3.1.2"
-          }
-        },
-        "lodash._basecopy": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-          "dev": true
-        },
-        "lodash._basedifference": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
-          "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
-          "dev": true,
-          "requires": {
-            "lodash._baseindexof": "3.1.0",
-            "lodash._cacheindexof": "3.0.2",
-            "lodash._createcache": "3.1.2"
-          }
-        },
-        "lodash._baseflatten": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
-          "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
-          "dev": true,
-          "requires": {
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        },
-        "lodash._basefor": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-          "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
-          "dev": true
-        },
-        "lodash._baseindexof": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
-          "dev": true
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-          "dev": true
-        },
-        "lodash._cacheindexof": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
-          "dev": true
-        },
-        "lodash._createassigner": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-          "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-          "dev": true,
-          "requires": {
-            "lodash._bindcallback": "3.0.1",
-            "lodash._isiterateecall": "3.0.9",
-            "lodash.restparam": "3.6.1"
-          }
-        },
-        "lodash._createcache": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-          "dev": true,
-          "requires": {
-            "lodash._getnative": "3.9.1"
-          }
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-          "dev": true
-        },
-        "lodash._isiterateecall": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-          "dev": true
-        },
-        "lodash._pickbyarray": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
-          "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
-          "dev": true
-        },
-        "lodash._pickbycallback": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
-          "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
-          "dev": true,
-          "requires": {
-            "lodash._basefor": "3.0.3",
-            "lodash.keysin": "3.0.8"
-          }
-        },
-        "lodash.clonedeep": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-          "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
-          "dev": true,
-          "requires": {
-            "lodash._baseclone": "3.3.0",
-            "lodash._bindcallback": "3.0.1"
-          }
-        },
-        "lodash.isarguments": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-          "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-          "dev": true
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-          "dev": true
-        },
-        "lodash.isplainobject": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-          "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
-          "dev": true,
-          "requires": {
-            "lodash._basefor": "3.0.3",
-            "lodash.isarguments": "3.1.0",
-            "lodash.keysin": "3.0.8"
-          }
-        },
-        "lodash.istypedarray": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
-          "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
-          "dev": true
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true,
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        },
-        "lodash.keysin": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-          "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
-          "dev": true,
-          "requires": {
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        },
-        "lodash.merge": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
-          "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
-          "dev": true,
-          "requires": {
-            "lodash._arraycopy": "3.0.0",
-            "lodash._arrayeach": "3.0.0",
-            "lodash._createassigner": "3.1.1",
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4",
-            "lodash.isplainobject": "3.2.0",
-            "lodash.istypedarray": "3.0.6",
-            "lodash.keys": "3.1.2",
-            "lodash.keysin": "3.0.8",
-            "lodash.toplainobject": "3.0.0"
-          }
-        },
-        "lodash.omit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
-          "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
-          "dev": true,
-          "requires": {
-            "lodash._arraymap": "3.0.0",
-            "lodash._basedifference": "3.0.3",
-            "lodash._baseflatten": "3.1.4",
-            "lodash._bindcallback": "3.0.1",
-            "lodash._pickbyarray": "3.0.2",
-            "lodash._pickbycallback": "3.0.0",
-            "lodash.keysin": "3.0.8",
-            "lodash.restparam": "3.6.1"
-          }
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-          "dev": true
-        },
-        "lodash.toplainobject": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
-          "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
-          "dev": true,
-          "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash.keysin": "3.0.8"
-          }
-        },
-        "longest": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-          "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
-          "dev": true
-        },
-        "no-shadow-relaxed": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/no-shadow-relaxed/-/no-shadow-relaxed-1.0.1.tgz",
-          "integrity": "sha1-z2zAFAL0IwuE/TvYoVZG3d8i7fI=",
-          "dev": true,
-          "requires": {
-            "eslint": "0.24.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
-              "dev": true
-            },
-            "doctrine": {
-              "version": "0.6.4",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
-              "integrity": "sha1-gUKEkalC7xiwSSBW7aOADu5X1h0=",
-              "dev": true,
-              "requires": {
-                "esutils": "1.1.6",
-                "isarray": "0.0.1"
-              }
-            },
-            "eslint": {
-              "version": "0.24.1",
-              "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.24.1.tgz",
-              "integrity": "sha1-VKUICYVbllVyHG8u5Xs1HtzigQE=",
-              "dev": true,
-              "requires": {
-                "chalk": "1.1.3",
-                "concat-stream": "1.6.0",
-                "debug": "2.6.8",
-                "doctrine": "0.6.4",
-                "escape-string-regexp": "1.0.5",
-                "escope": "3.6.0",
-                "espree": "2.2.5",
-                "estraverse": "4.2.0",
-                "estraverse-fb": "1.3.2",
-                "globals": "8.18.0",
-                "inquirer": "0.8.5",
-                "is-my-json-valid": "2.16.1",
-                "js-yaml": "3.10.0",
-                "minimatch": "2.0.10",
-                "mkdirp": "0.5.1",
-                "object-assign": "2.1.1",
-                "optionator": "0.5.0",
-                "path-is-absolute": "1.0.1",
-                "strip-json-comments": "1.0.4",
-                "text-table": "0.2.0",
-                "user-home": "1.1.1",
-                "xml-escape": "1.0.0"
-              }
-            },
-            "inquirer": {
-              "version": "0.8.5",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
-              "integrity": "sha1-29dAz2yjtzEpamPOb22WGFHzNt8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "1.1.1",
-                "chalk": "1.1.3",
-                "cli-width": "1.1.1",
-                "figures": "1.7.0",
-                "lodash": "3.10.1",
-                "readline2": "0.1.1",
-                "rx": "2.5.3",
-                "through": "2.3.8"
-              }
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            }
-          }
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0"
-          }
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
-          }
-        },
-        "optionator": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-          "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
-          "dev": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "1.0.7",
-            "levn": "0.2.5",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "0.0.3"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-          "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "readline2": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-          "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
-          "dev": true,
-          "requires": {
-            "mute-stream": "0.0.4",
-            "strip-ansi": "2.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-              "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "1.1.1"
-              }
-            }
-          }
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            }
-          }
-        },
-        "run-async": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "rx": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
-          "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=",
-          "dev": true
-        },
-        "rx-lite": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz",
-          "integrity": "sha1-X+9C1Nbna6tRmdIXEyfbcJ5Y5jQ=",
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
-        },
-        "shelljs": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-          "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "source-map-support": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
-          "integrity": "sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
-            }
-          }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-          "dev": true
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        },
-        "to-double-quotes": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
-          "integrity": "sha1-u27TbHhjTD1k/YelGtWGDcWU7f0=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "3.0.2"
-          }
-        },
-        "to-single-quotes": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
-          "integrity": "sha1-LuqBma8myhFx9TV8WeGS1WXuUxM=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "3.0.2"
-          }
-        },
-        "tryit": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-          "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-          "dev": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true,
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        },
-        "write": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-          "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-          "dev": true,
-          "requires": {
-            "mkdirp": "0.5.1"
-          }
-        },
-        "xml-escape": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
-          "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
-        }
       }
     },
     "latest-version": {
@@ -7113,6 +5631,11 @@
         "lodash.restparam": "3.6.1"
       }
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -7125,6 +5648,31 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -7135,6 +5683,11 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -7171,6 +5724,21 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
+    "martinez-polygon-clipping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.3.3.tgz",
+      "integrity": "sha512-SWnF0uzCdo/EUSoJuT3aqN8fC4pWLALqUNdH1xd/dHYBi1DLIdbeJLypbPQN65VCCODnHKMBVQbFhbLdjpBPFQ==",
+      "requires": {
+        "avl": "1.4.2",
+        "tinyqueue": "1.2.3"
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
     "micromatch": {
@@ -7399,6 +5967,12 @@
           "dev": true
         }
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
     },
     "moment": {
       "version": "2.18.1",
@@ -8178,6 +6752,17 @@
       "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
+    "proxyquire": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
+      "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
+      "dev": true,
+      "requires": {
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.1.7"
+      }
+    },
     "ps-tree": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
@@ -8684,6 +7269,12 @@
         }
       }
     },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
     "safe-buffer": {
       "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
@@ -8974,6 +7565,12 @@
         }
       }
     },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "dev": true
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -9209,285 +7806,6 @@
         "has-flag": "2.0.0"
       }
     },
-    "tape": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
-      "integrity": "sha1-9qn+xBzFCh3lD6M2A6tYCZH2Bo4=",
-      "dev": true,
-      "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.2",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.3.0",
-        "resolve": "1.4.0",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "deep-equal": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-          "dev": true
-        },
-        "define-properties": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-          "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-          "dev": true,
-          "requires": {
-            "foreach": "2.0.5",
-            "object-keys": "1.0.11"
-          }
-        },
-        "defined": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-          "dev": true
-        },
-        "es-abstract": {
-          "version": "1.8.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
-          "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "1.1.1",
-            "function-bind": "1.1.1",
-            "has": "1.0.1",
-            "is-callable": "1.1.3",
-            "is-regex": "1.0.4"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-          "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-          "dev": true,
-          "requires": {
-            "is-callable": "1.1.3",
-            "is-date-object": "1.0.1",
-            "is-symbol": "1.0.1"
-          }
-        },
-        "for-each": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-          "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-          "dev": true,
-          "requires": {
-            "is-function": "1.0.1"
-          }
-        },
-        "foreach": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-          "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-          "dev": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "has": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-          "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-          "dev": true,
-          "requires": {
-            "function-bind": "1.1.1"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-          "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-          "dev": true
-        },
-        "is-date-object": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-          "dev": true
-        },
-        "is-function": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-          "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-          "dev": true,
-          "requires": {
-            "has": "1.0.1"
-          }
-        },
-        "is-symbol": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-          "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "object-inspect": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
-          "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-          "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
-          "dev": true,
-          "requires": {
-            "path-parse": "1.0.5"
-          }
-        },
-        "resumer": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-          "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-          "dev": true,
-          "requires": {
-            "through": "2.3.8"
-          }
-        },
-        "string.prototype.trim": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-          "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-          "dev": true,
-          "requires": {
-            "define-properties": "1.1.2",
-            "es-abstract": "1.8.2",
-            "function-bind": "1.1.1"
-          }
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        }
-      }
-    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -9513,6 +7831,11 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
+    },
+    "tinyqueue": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
     },
     "tmp": {
       "version": "0.0.26",
@@ -9600,19 +7923,6 @@
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         }
       }
-    },
-    "turf-bbox-polygon": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/turf-bbox-polygon/-/turf-bbox-polygon-1.0.2.tgz",
-      "integrity": "sha1-SIsiP7eHdhFh+jMr/6Hdj9W9CdE=",
-      "requires": {
-        "turf-polygon": "1.0.3"
-      }
-    },
-    "turf-polygon": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-1.0.3.tgz",
-      "integrity": "sha1-Zx3TSEmGRQkoGvGOI29np0SMY2M="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -9866,7 +8176,7 @@
       "integrity": "sha1-mKuIL4XhalJjMlB/EB9aeEEWIng=",
       "requires": {
         "boom": "4.3.1",
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "boom": {
@@ -9874,13 +8184,8 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,10 +20,15 @@
   },
   "homepage": "https://github.com/hotosm/oam-catalog",
   "dependencies": {
+    "@mapbox/sphericalmercator": "^1.0.5",
+    "@turf/area": "^6.0.1",
     "@turf/bbox": "^4.7.3",
+    "@turf/bbox-polygon": "^6.0.1",
     "@turf/envelope": "^5.0.4",
+    "@turf/intersect": "^6.1.2",
     "@turf/invariant": "^4.7.3",
     "@turf/meta": "^6.0.1",
+    "@turf/union": "^6.0.2",
     "async": "2.1.4",
     "aws-sdk": "^2.66.0",
     "babel": "^5.8.21",
@@ -57,7 +62,6 @@
     "request": "^2.60.0",
     "sendgrid": "^1.9.2",
     "tmp": "0.0.26",
-    "turf-bbox-polygon": "^1.0.1",
     "uuid": "^3.0.1",
     "wellknown": "^0.3.1",
     "xtend": "^4.0.0"

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,8 +1,13 @@
 'use strict';
 
 var _ = require('lodash');
+// var area = require('@turf/area').default;
+var bboxPolygon = require('@turf/bbox-polygon').default;
 var Boom = require('boom');
+// var intersect = require('@turf/intersect').default;
 var Joi = require('joi');
+var merc = new (require('@mapbox/sphericalmercator'))();
+// var union = require('@turf/union').default;
 
 var User = require('../models/user');
 var Meta = require('../models/meta');
@@ -87,6 +92,154 @@ module.exports = [
         });
       }).catch(function (err) {
         reply(Boom.badImplementation(err));
+      });
+    }
+  },
+
+  {
+    method: 'GET',
+    path: '/user/{user}/catalog.json',
+    config: {
+      tags: ['disablePlugins']
+    },
+    handler: (request, reply) => {
+      const { user } = request.params;
+
+      return Promise.all([
+        User.findOne({
+          _id: user
+        }, {
+          name: 1,
+          website: 1
+        }),
+        Meta.find({
+          user
+        }, {
+          bbox: 1, gsd: 1
+        })
+      ])
+        .then(([user, images]) => {
+          const approximateZoom = Math.floor(images
+            .map(meta => Math.ceil(Math.log2(2 * Math.PI * 6378137 / (meta.gsd * 256))))
+            .reduce((a, b) => a + b) / images.length);
+
+          const bounds = images.reduce((bbox, meta) =>
+            [
+              Math.min(bbox[0], meta.bbox[0]),
+              Math.min(bbox[1], meta.bbox[1]),
+              Math.max(bbox[2], meta.bbox[2]),
+              Math.max(bbox[3], meta.bbox[3])
+            ], [Infinity, Infinity, -Infinity, -Infinity]);
+
+          return reply({
+            name: user.name,
+            bounds: bounds,
+            center: [
+              (bounds[0] + bounds[2]) / 2,
+              (bounds[1] + bounds[3]) / 2,
+              approximateZoom - 3
+            ],
+            maxzoom: approximateZoom + 3,
+            minzoom: approximateZoom - 10
+          });
+        })
+        .catch(err => reply(Boom.badImplementation(err.message)));
+    }
+  },
+
+  {
+    method: 'GET',
+    path: '/user/{user}/{z}/{x}/{y}.json',
+    config: {
+      tags: ['disablePlugins']
+    },
+    handler: (request, reply) => {
+      const { user, z, x, y } = request.params;
+
+      const bbox = merc.bbox(x, y, z);
+      const { geometry } = bboxPolygon(bbox);
+
+      return Meta.find({
+        user,
+        geojson: {
+          $geoIntersects: {
+            $geometry: geometry
+          }
+        }
+      }, {
+        acquisition_end: 1,
+        geojson: 1,
+        gsd: 1,
+        title: 1,
+        uuid: 1
+      }, {
+        sort: {
+          gsd: 1,
+          acquisition_end: -1
+        }
+      }).then(images => {
+        if (images.length === 0) {
+          return reply(Boom.notFound());
+        }
+
+        // NOTE source prioritization is currently disabled due to
+        // https://github.com/w8r/martinez/issues/74, which is triggered by
+        // geometries in the Zanzibar imagery
+        const sources = images;
+
+        // // for filtering; more readable than embedding everything into reduce()
+        // let tileArea = area(geometry);
+        // let totalArea = 0;
+        // let totalOverlap = null;
+        // let filled = false;
+        //
+        // // sort by overlap
+        // const sources = images
+        //   // calculate overlap with the target tile
+        //   .map(image => Object.assign(image, {
+        //     overlap: intersect(geometry, image.geojson)
+        //   }))
+        //   // sort by overlap
+        //   .sort((a, b) => area(b.overlap) - area(a.overlap))
+        //   // filter unnecessary sources
+        //   .filter(x => {
+        //     if (filled) {
+        //       // already full
+        //       return false;
+        //     }
+        //
+        //     const newOverlap = totalOverlap == null ? x.overlap : union(totalOverlap, x.overlap);
+        //     const newArea = area(newOverlap);
+        //
+        //     if (newArea > totalArea) {
+        //       // this source contributes
+        //       if (newArea === tileArea) {
+        //         // now full
+        //         filled = true;
+        //       }
+        //
+        //       totalOverlap = newOverlap;
+        //       totalArea = newArea;
+        //       return true;
+        //     }
+        //
+        //     return false;
+        //   });
+
+        return reply(sources
+          .map(meta => ({
+            url: meta.uuid,
+            name: meta.title,
+            acquired_at: meta.acquisition_end,
+            resolution: meta.gsd,
+            recipes: {
+              imagery: true
+            }
+          })));
+      })
+      .catch(err => {
+        console.warn(err.stack);
+        return reply(Boom.badImplementation(err.message));
       });
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,28 @@
 # yarn lockfile v1
 
 
+"@mapbox/sphericalmercator@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz#70237b9774095ed1cfdbcea7a8fd1fc82b2691f2"
+
+"@turf/area@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/area/-/area-6.0.1.tgz#50ed63c70ef2bdb72952384f1594319d94f3b051"
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+
 "@turf/bbox-polygon@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz#6aeba4ed51d85d296e0f7c38b88c339f01eee024"
   dependencies:
     "@turf/helpers" "^5.1.5"
+
+"@turf/bbox-polygon@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-6.0.1.tgz#ae0fbb14558831fb34538aae089a23d3336c6379"
+  dependencies:
+    "@turf/helpers" "6.x"
 
 "@turf/bbox@^4.7.3":
   version "4.7.3"
@@ -37,9 +54,29 @@
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
 
+"@turf/intersect@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@turf/intersect/-/intersect-6.1.2.tgz#eaf5e8915af601978a8b65851bc73db57cf5919c"
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    martinez-polygon-clipping "*"
+
+"@turf/invariant@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.0.1.tgz#45581b41f82d91b682cef427e897c840d1741757"
+  dependencies:
+    "@turf/helpers" "6.x"
+
 "@turf/invariant@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-4.7.3.tgz#538f367d23c113fc849d70c9a524b8563874601d"
+
+"@turf/meta@6.x", "@turf/meta@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.0.1.tgz#cf6f3f2263a3d24fc8d6a7e90f0420bbc44c090d"
+  dependencies:
+    "@turf/helpers" "6.x"
 
 "@turf/meta@^4.7.3":
   version "4.7.4"
@@ -51,11 +88,13 @@
   dependencies:
     "@turf/helpers" "^5.1.5"
 
-"@turf/meta@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.0.1.tgz#cf6f3f2263a3d24fc8d6a7e90f0420bbc44c090d"
+"@turf/union@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/union/-/union-6.0.2.tgz#6821d7842f048cfcfe1ae3b7c36fec73bd7e89cd"
   dependencies:
     "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    martinez-polygon-clipping "*"
 
 abbrev@1:
   version "1.1.1"
@@ -337,6 +376,10 @@ asynckit@^0.4.0:
 atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
+
+avl@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/avl/-/avl-1.4.2.tgz#55cef61e6e6ae26a899a929f5c57d25b4afb2cae"
 
 aws-sdk@^2.66.0:
   version "2.171.0"
@@ -2842,6 +2885,13 @@ markdown-it@^5.0.2:
     mdurl "~1.0.1"
     uc.micro "^1.0.0"
 
+martinez-polygon-clipping@*:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/martinez-polygon-clipping/-/martinez-polygon-clipping-0.3.3.tgz#a7b9429c9d13cb118a86c97a5e1af5a62aedb6d9"
+  dependencies:
+    avl "^1.4.1"
+    tinyqueue "^1.2.0"
+
 mdurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
@@ -4296,6 +4346,10 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
+tinyqueue@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-1.2.3.tgz#b6a61de23060584da29f82362e45df1ec7353f3d"
+
 tmp@0.0.26:
   version "0.0.26"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.26.tgz#9efa820ce2a10f81f8979555bace3f15526ce1f2"
@@ -4376,16 +4430,6 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
-
-turf-bbox-polygon@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/turf-bbox-polygon/-/turf-bbox-polygon-1.0.2.tgz#488b223fb787761161fa332bffa1dd8fd5bd09d1"
-  dependencies:
-    turf-polygon "^1.0.2"
-
-turf-polygon@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/turf-polygon/-/turf-polygon-1.0.3.tgz#671dd34849864509281af18e236f67a7448c6363"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
This is a refined version of #122 specific to users (and feels sufficient to deploy from my perspective).

It allows marblecutter-openaerialmap w/ https://github.com/mojodna/marblecutter-openaerialmap/blob/master/openaerialmap/web.py#L274-L292 to render tiles from `/user/<id>/{z}/{x}/{y}.png`.

It includes logic to prioritize sources that more fully cover a given tile (preferring recent + higher resolution versions), but that's currently disabled due to the Zanzibar data hitting https://github.com/w8r/martinez/issues/74.

(This is the same logic we'll want for the global mosaic, especially since the likelihood of more sources fully covering a given tile is substantially higher.)