### PR TITLE
Add a Hapi plugin that reports errors to Sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "hapi": "^16.4.3",
     "hapi-auth-cookie": "^7.0.0",
     "hapi-auth-jwt2": "^7.3.0",
+    "hapi-raven": "^6.0.0",
     "hapi-router": "^3.5.0",
     "joi": "^10.6.0",
     "jsonwebtoken": "^8.1.0",

--- a/services/server.js
+++ b/services/server.js
@@ -63,6 +63,12 @@ Server.prototype.start = function (cb) {
     },
     {
       register: require('../plugins/paginate.js')
+    },
+    {
+      register: require('hapi-raven'),
+      options: {
+        dsn: process.env.SENTRY_DSN
+      }
     }
   ], function (err) {
     if (err) throw err;


### PR DESCRIPTION
When deploying, set `SENTRY_DSN` in the environment (provided offline, available through sentry.io).