### PR TITLE
Remove extension from TMS templates

### DIFF
--- a/routes/uploads.js
+++ b/routes/uploads.js
@@ -383,7 +383,7 @@ function updateUploadMetadata (request, imageId) {
     meta.uploaded_at = new Date();
     meta.properties = Object.assign(meta.properties, request.payload.properties);
     meta.properties.thumbnail = meta.properties.thumbnail.replace(/^s3:\/\/([^/]+)\//, `https://$1.${config.s3PublicDomain}/`);
-    meta.properties.tms = `${config.tilerBaseUrl}/${request.params.id}/${request.params.sceneIdx}/${request.params.imageId}/{z}/{x}/{y}.png`;
+    meta.properties.tms = `${config.tilerBaseUrl}/${request.params.id}/${request.params.sceneIdx}/${request.params.imageId}/{z}/{x}/{y}`;
     meta.properties.wmts = `${config.tilerBaseUrl}/${request.params.id}/${request.params.sceneIdx}/${request.params.imageId}/wmts`;
 
     // remove duplicated properties

--- a/test/fixtures/metadata.json
+++ b/test/fixtures/metadata.json
@@ -6,7 +6,7 @@
     "contact": "Aeracoop,aeracoop@gmail.com",
     "properties": {
         "thumbnail": "http://oin-hotosm.s3.amazonaws.com/593164d3e407d7001138610d/0/6f407df9-a342-4fe8-a802-6cd81ca8974a_thumb.png",
-        "tms": "https://tiles.openaerialmap.org/593164d3e407d7001138610d/0/6f407df9-a342-4fe8-a802-6cd81ca8974a/{z}/{x}/{y}.png",
+        "tms": "https://tiles.openaerialmap.org/593164d3e407d7001138610d/0/6f407df9-a342-4fe8-a802-6cd81ca8974a/{z}/{x}/{y}",
         "wmts": "https://tiles.openaerialmap.org/593164d3e407d7001138610d/0/6f407df9-a342-4fe8-a802-6cd81ca8974a/wmts",
         "sensor": "DJI Mavic",
         "license": "CC-BY 4.0",

--- a/test/integration/test_imagery.js
+++ b/test/integration/test_imagery.js
@@ -32,7 +32,7 @@ describe('Imagery CRUD', function () {
     expect(prereqs.image.bbox).to.deep.eq([129, 29, 146, 54]);
 
     // TODO: Fetch these and check they're good too
-    expect(prereqs.image.properties.tms).to.include('/{z}/{x}/{y}.png');
+    expect(prereqs.image.properties.tms).to.include('/{z}/{x}/{y}');
     expect(prereqs.image.meta_uri).to.include('_meta.json');
   });
 


### PR DESCRIPTION
This allows the tiler to pick appropriate formats depending on transparency needs without conflicting with the convention that the extension dictates the format.

Tiler dependencies have been deployed; see http://tiles.staging.openaerialmap.org/user/59e632ffeb530b000e5f9436/preview#20/-16.89015/168.55042 for a source that conditionally renders PNGs and JPEGs.

The existing URLs will continue to work, but we may want to rewrite the TMS metadata in S3 to be able to take advantage of this functionality.