### PR TITLE
Fix an issue with transcoder when running in docker-compose

### DIFF
--- a/services/transcoder.js
+++ b/services/transcoder.js
@@ -50,7 +50,7 @@ module.exports.transcode = (sourceUrl, output, metaUrl, callback) => {
       );
     }
 
-    return callback();
+    return _callback();
   });
 };
 


### PR DESCRIPTION
I am not 100% sure this is the right fix, but when running oam-api locally with the docker-compose
image (to hack on oam-browser), I saw that the transcoder was hanging after finishing one image.

This seems to fix it.